### PR TITLE
Add initial Rigid Body physics system

### DIFF
--- a/include/math/constants.h
+++ b/include/math/constants.h
@@ -1,0 +1,10 @@
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#include <glm/glm.hpp>
+
+constexpr double kPi = 3.1415926535;
+constexpr double kGravity = 9.806650;
+constexpr double kDamping = 0.3;
+
+#endif

--- a/include/math/math_utils.h
+++ b/include/math/math_utils.h
@@ -1,0 +1,6 @@
+#include <glm/glm.hpp>
+
+glm::mat3 GetCubeInertiaTensor(float mass, float w, float h, float d);
+
+glm::mat3 GetSquarePyramidInertiaTensor(float mass, float b, float h);
+

--- a/include/rigid_body.h
+++ b/include/rigid_body.h
@@ -1,0 +1,63 @@
+#ifndef RIGID_BODY_H
+#define RIGID_BODY_H
+
+#include <glm/ext/matrix_float3x3.hpp>
+#include <glm/ext/matrix_float4x4.hpp>
+#include <glm/ext/vector_float3.hpp>
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <wrapgl/mesh.h>
+#include <wrapgl/renderer.h>
+
+enum Shape {
+        kCube,
+        kPyramid,
+};
+
+class RigidBody {
+        float mass_;
+
+        glm::vec3 position_; // position_ is also the position of center of mass. 
+        glm::quat rotation_;
+        glm::vec3 scale_;
+
+        glm::vec3 linear_velocity_;
+        glm::vec3 angular_velocity_;
+
+        glm::mat3 inertia_tensor_;
+
+        glm::mat4 cached_model_;
+        wgl::Mesh *mesh_;
+
+        bool dirty_;
+
+public:
+        RigidBody(Shape shape, float mass, const glm::vec3 &scale);
+        ~RigidBody();
+
+        // @brief This method integrates linear acceleration into the linear 
+        //        velocity of the body.
+        //
+        // @param force The force to apply to the body.
+        // @param dt Delta time.
+        void IntegrateLinearAcceleration(glm::vec3 force, float dt);               
+        void IntegrateLinearImpulse(glm::vec3 impulse);
+
+        void IntegrateAngularAcceleration(glm::vec3 force, glm::vec3 r, float dt);
+        void IntegrateAngularImpulse(glm::vec3 impulse, glm::vec3 r);
+
+        void IntegrateAccelerations(glm::vec3 forces, glm::vec3 r, float dt);
+        void IntegrateImpulses(glm::vec3 impulses, glm::vec3 r, float dt);
+
+        void IntegrateVelocities(float dt);
+
+        void IntegrateLinearVelocity(float dt);
+        void IntegrateAngularVelocity(float dt);
+
+        void Draw(wgl::Renderer &renderer);
+
+        glm::mat4 CalculateModelMatrix();
+};
+
+#endif
+

--- a/include/util/util.h
+++ b/include/util/util.h
@@ -1,0 +1,4 @@
+#include <wrapgl/vertex_layout.h>
+
+wgl::VertexLayout GetGlobalVertexLayout();
+

--- a/src/math/math_utils.cpp
+++ b/src/math/math_utils.cpp
@@ -1,0 +1,29 @@
+#include "../../include/math/math_utils.h"
+
+glm::mat3 GetCubeInertiaTensor(float mass, float w, float h, float d) {
+    float ix = (mass / 12.0f) * (h*h + d*d);
+    float iy = (mass / 12.0f) * (w*w + d*d);
+    float iz = (mass / 12.0f) * (w*w + h*h);
+    static glm::mat3 tensor = glm::mat3(
+        ix, 0, 0,
+        0, iy, 0,
+        0, 0, iz
+    );
+
+    return tensor; 
+}
+
+glm::mat3 GetSquarePyramidInertiaTensor(float mass, float b, float h) {
+    float i_xx = (mass / 20.0f) * (4.0f * h * h + b * b);
+    float i_yy = i_xx;
+    float i_zz = (mass / 10.0f) * (b * b);
+    
+    static glm::mat3 tensor = glm::mat3(
+        i_xx, 0.0f, 0.0f,
+        0.0f, i_yy, 0.0f,
+        0.0f, 0.0f, i_zz
+    );
+
+    return tensor;
+}
+

--- a/src/rigid_body.cpp
+++ b/src/rigid_body.cpp
@@ -1,0 +1,152 @@
+#include "../include/rigid_body.h"
+#include "../include/math/constants.h"
+#include "../include/math/math_utils.h"
+#include "../include/util/util.h"
+#include <glm/geometric.hpp>
+#include <glm/matrix.hpp>
+#include <stdexcept>
+#include <wrapgl/mesh_factory.h>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/quaternion.hpp>
+#include <glm/ext/matrix_transform.hpp>
+
+using namespace glm;
+
+RigidBody::RigidBody(Shape shape, float mass, const vec3 &scale)
+{
+        mass_ = mass;
+
+        position_ = vec3(0.0f);
+        rotation_ = quat(1.0f, 0.0f, 0.0f, 0.0f);
+        scale_    = scale;
+
+        linear_velocity_  = vec3(0.0f);
+        angular_velocity_ = vec3(0.0f);
+
+        vec3 rgb = vec3(1.0f, 0.2f, 0.3f);
+
+        wgl::VertexLayout layout = GetGlobalVertexLayout();
+
+        switch (shape) {
+                case kCube:
+                        inertia_tensor_ = GetCubeInertiaTensor(mass_, scale.x, scale.y, scale.z);
+                        mesh_ = wgl::MeshFactory::GetCube(layout, &rgb);
+                        break;
+                case kPyramid:
+                        inertia_tensor_ = GetSquarePyramidInertiaTensor(mass_, scale.z, scale.y);
+                        mesh_ = wgl::MeshFactory::GetPyramid(layout, &rgb);
+                        break;
+                default:
+                        throw std::runtime_error("What?");
+        }
+
+        cached_model_ = mat4(1.0f);
+        dirty_ = true;
+}
+
+RigidBody::~RigidBody()
+{
+        wgl::MeshFactory::DestroyMesh(mesh_);
+}
+
+void RigidBody::IntegrateLinearAcceleration(vec3 force, float dt)
+{
+        vec3 acc = force / mass_;
+
+        linear_velocity_ += acc * dt;
+        linear_velocity_ *= (1 - kDamping * dt);
+}
+
+void RigidBody::IntegrateLinearImpulse(glm::vec3 impulse)
+{
+        linear_velocity_ += (impulse / mass_);
+}
+
+void RigidBody::IntegrateAngularAcceleration(vec3 force, vec3 r, float dt)
+{
+        mat3 R = mat3_cast(rotation_); // convert quaternion to 3x3 rotation
+        mat3 I_world = R * inertia_tensor_ * transpose(R);
+
+        // r is just the distance from the center of mass (position_) where
+        // the force was applied.
+        vec3 applied_torque = cross(r, force);
+
+        // Gyroscopic term.
+        vec3 gyro_term = cross(angular_velocity_, (inertia_tensor_ * angular_velocity_));
+
+        // Total torque.
+        vec3 net_torque = applied_torque - gyro_term;
+
+        // use I_world to compute angular acceleration
+        vec3 angular_acc = inverse(I_world) * applied_torque;
+
+        angular_velocity_ += angular_acc * dt;
+}
+
+void RigidBody::IntegrateAngularImpulse(glm::vec3 impulse, glm::vec3 r)
+{
+        vec3 angular_impulse = cross(r, impulse);
+
+        angular_velocity_ += inverse(inertia_tensor_) * angular_impulse;
+}
+
+void RigidBody::IntegrateLinearVelocity(float dt)
+{
+        position_ += linear_velocity_ * dt; 
+        dirty_ = true;
+}
+
+void RigidBody::IntegrateAngularVelocity(float dt)
+{
+        glm::quat omega_quat(0, angular_velocity_.x, angular_velocity_.y, angular_velocity_.z);
+        glm::quat q_dot = 0.5f * (omega_quat * rotation_);
+
+        rotation_ += dt * q_dot;
+        rotation_ = glm::normalize(rotation_);
+
+        dirty_ = true;
+}
+
+void RigidBody::IntegrateAccelerations(glm::vec3 forces, glm::vec3 r, float dt)
+{
+        IntegrateLinearAcceleration(forces, dt);
+        IntegrateAngularAcceleration(forces, r, dt);
+}
+
+void RigidBody::IntegrateImpulses(glm::vec3 impulses, glm::vec3 r, float dt)
+{
+        IntegrateLinearImpulse(impulses);
+        IntegrateAngularImpulse(impulses, r);
+}
+
+void RigidBody::IntegrateVelocities(float dt)
+{
+        IntegrateLinearVelocity(dt);
+        IntegrateAngularVelocity(dt);
+}
+
+void RigidBody::Draw(wgl::Renderer &renderer)
+{
+        renderer.SetUniformMatrix4f("model", CalculateModelMatrix());
+        mesh_->Draw(renderer);
+}
+
+glm::mat4 RigidBody::CalculateModelMatrix()
+{
+        if (!dirty_) {
+                return cached_model_;
+        }
+
+        mat4 model = mat4(1.0f);
+        model = translate(model, position_);
+        model *= toMat4(rotation_);
+        model = scale(model, scale_);
+
+        dirty_ = false;
+
+        cached_model_ = model;
+
+        return cached_model_;
+}
+

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -1,0 +1,20 @@
+#include "../../include/util/util.h"
+
+#include <wrapgl/vertex_layout.h>
+
+static bool setup = false;
+
+wgl::VertexLayout GetGlobalVertexLayout()
+{
+        static wgl::VertexLayout layout;
+        static bool setup = false;
+
+        if (!setup) {
+                layout.AddAttr(0, wgl::AttributeType::kPosition, 3, GL_FLOAT, false);
+                layout.AddAttr(1, wgl::AttributeType::kColor, 3, GL_FLOAT, true);
+                setup = true;
+        }
+
+        return layout;
+}
+


### PR DESCRIPTION
This PR set the groundwork for future features (collisions, constraints, etc.).

### Key changes

- Added `RigidBody` class with support for:
    - Linear and angular acceleration and velocity integration.
    - Linear and angular impulse-based velocity integration.
    - Wrapped draw call to easily draw body with it's model matrix.
- Added `math/constants.h` for reusable physics constants (e.g., gravity).
- Integrated RigidBody into the main loop:
    - Compute delta-time with `std::chrono`.
    - Apply gravity each frame (acceleration).
    - Apply an initial impulse on first iteration of the loop.
- Removed temporary code from initial commit.

