### PR TITLE
Added Pendulum class that supports multiple bodies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(pheV4 LANGUAGES CXX)
 
-# Set C++ standard
+# ---------- Basic project settings ----------
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -10,15 +10,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build)
 
-# Add include folder
-include_directories(${CMAKE_SOURCE_DIR}/include)
-
-# Find external libraries
+# ---------- Find external libraries ----------
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(glfw3 REQUIRED)
 
-# If wrapgl is installed system-wide (headers in /usr/include/wrapgl/ and library in /usr/lib)
+# wrapgl (custom lib) - fail early if missing
 find_path(WRAPGL_INCLUDE_DIR wrapgl/wrapgl.h)
 find_library(WRAPGL_LIBRARY wrapgl)
 
@@ -26,20 +23,39 @@ if(NOT WRAPGL_INCLUDE_DIR OR NOT WRAPGL_LIBRARY)
     message(FATAL_ERROR "wrapgl not found. Please provide WRAPGL_INCLUDE_DIR and WRAPGL_LIBRARY.")
 endif()
 
-include_directories(${WRAPGL_INCLUDE_DIR})
+# ---------- Automatic source discovery (robust) ----------
+# CONFIGURE_DEPENDS makes CMake re-run when files are added/removed.
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS
+     ${CMAKE_SOURCE_DIR}/src/*.cpp)
 
-# Gather sources recursively from src/
-file(GLOB_RECURSE SOURCES ${CMAKE_SOURCE_DIR}/src/*.cpp)
+# Helpful debug output so you can see what CMake found
+message(STATUS "Detected source files:")
+foreach(_src IN LISTS SOURCES)
+    message(STATUS "  ${_src}")
+endforeach()
 
-# Add executable
+# ---------- Target ----------
 add_executable(${PROJECT_NAME} ${SOURCES})
 
-# Link libraries
+# Include directories (target-scoped, safer than global include_directories)
+# Keep project headers first so your include/ wins over system includes if needed.
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        ${WRAPGL_INCLUDE_DIR}
+)
+
+# ---------- Link libraries ----------
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-    OpenGL::GL
-    GLEW::GLEW
-    glfw
-    ${WRAPGL_LIBRARY}
+        OpenGL::GL
+        GLEW::GLEW
+        glfw
+        ${WRAPGL_LIBRARY}
 )
+
+# ---------- Optional: sane compile flags for GCC/Clang ----------
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic)
+endif()
 

--- a/include/math/constants.h
+++ b/include/math/constants.h
@@ -6,6 +6,6 @@
 constexpr double kPi = 3.1415926535;
 constexpr double kGravity = 9.806650;
 constexpr double kDamping = 0.3;
-constexpr double kConstraintStiffness = 0.2;
+constexpr double kConstraintStiffness = 1.0;
 
 #endif

--- a/include/math/constants.h
+++ b/include/math/constants.h
@@ -6,5 +6,6 @@
 constexpr double kPi = 3.1415926535;
 constexpr double kGravity = 9.806650;
 constexpr double kDamping = 0.3;
+constexpr double kConstraintStiffness = 0.2;
 
 #endif

--- a/include/math/constants.h
+++ b/include/math/constants.h
@@ -5,7 +5,7 @@
 
 constexpr double kPi = 3.1415926535;
 constexpr double kGravity = 9.806650;
-constexpr double kDamping = 0.3;
+constexpr double kDamping = 0.0;
 constexpr double kConstraintStiffness = 1.0;
 
 #endif

--- a/include/pendulum.h
+++ b/include/pendulum.h
@@ -1,0 +1,28 @@
+#ifndef PENDULUM_H
+#define PENDULUM_H
+
+#include <glm/ext/vector_float3.hpp>
+#include <wrapgl/renderer.h>
+
+#include "rigid_body.h"
+
+class Pendulum {
+        RigidBody pivot_, bob_;
+
+        glm::vec3 pivot_attach_, bob_attach_;
+
+        float rod_lenght_;
+
+public:
+        Pendulum(const glm::vec3 &pivot_pos, float rod_lenght);
+
+        inline RigidBody* GetBob() { return &bob_; }
+        inline RigidBody* GetPivot() { return &pivot_; }
+
+        void Update(float dt);
+
+        void Draw(wgl::Renderer &renderer);
+};
+
+#endif
+

--- a/include/pendulum.h
+++ b/include/pendulum.h
@@ -2,30 +2,34 @@
 #define PENDULUM_H
 
 #include <glm/ext/vector_float3.hpp>
+#include <utility>
+#include <vector>
 #include <wrapgl/renderer.h>
 
 #include "rigid_body.h"
 
 class Pendulum {
-        RigidBody pivot_, bob_;
+        std::vector<RigidBody> bobs_;
 
-        glm::vec3 pivot_attach_, bob_attach_;
+        std::vector<glm::vec3> bobs_attach_;
 
-        // World position of the pivot and bob attachment point to each other.
-        glm::vec3 pivot_attach_wrld_, bob_attach_wrld_;
+        // World position of the bobs attachment point to each other.
+        // bobs_attach_wrld[i] are the attachment points to bobs_[i]
+        std::vector<glm::vec3> bobs_attach_wrld_;
 
         float rod_length_;
 
         unsigned int line_vao_, line_vbo_; 
 
 public:
-        Pendulum(const glm::vec3 &pivot_pos, float rod_length, bool is_static);
+        // @param num_bobs The number of bobs.
+        // @param rod_length The length of the rod between each bob.
+        // @param is_static Whether the first bob will be static or not.
+        Pendulum(const glm::vec3 &pos, size_t num_bobs, float rod_length, bool is_static);
 
-        void UpdatePivotAttachWorld();
-        void UpdateBobAttachWorld();
+        void UpdateBobAttachWorld(size_t i);
 
-        inline RigidBody* GetBob() { return &bob_; }
-        inline RigidBody* GetPivot() { return &pivot_; }
+        inline RigidBody* GetBob(size_t i) { return &bobs_[i]; }
 
         void Update(float dt);
 

--- a/include/pendulum.h
+++ b/include/pendulum.h
@@ -11,10 +11,18 @@ class Pendulum {
 
         glm::vec3 pivot_attach_, bob_attach_;
 
-        float rod_lenght_;
+        // World position of the pivot and bob attachment point to each other.
+        glm::vec3 pivot_attach_wrld_, bob_attach_wrld_;
+
+        float rod_length_;
+
+        unsigned int line_vao_, line_vbo_; 
 
 public:
-        Pendulum(const glm::vec3 &pivot_pos, float rod_lenght);
+        Pendulum(const glm::vec3 &pivot_pos, float rod_length, bool is_static);
+
+        void UpdatePivotAttachWorld();
+        void UpdateBobAttachWorld();
 
         inline RigidBody* GetBob() { return &bob_; }
         inline RigidBody* GetPivot() { return &pivot_; }

--- a/include/rigid_body.h
+++ b/include/rigid_body.h
@@ -25,15 +25,17 @@ class RigidBody {
         glm::vec3 angular_velocity_;
 
         glm::mat3 inertia_tensor_;
-
+        glm::mat3 cached_inv_inertia_tensor; // World inverse inertia tensor.
         glm::mat4 cached_model_;
+
         wgl::Mesh *mesh_;
 
+        bool is_static_;
         bool dirty_;
 
 public:
         RigidBody() = default;
-        RigidBody(Shape shape, float mass, const glm::vec3 &scale);
+        RigidBody(Shape shape, float mass, const glm::vec3 &scale, bool is_static);
         ~RigidBody();
 
         // @brief This method integrates linear acceleration into the linear 
@@ -59,11 +61,17 @@ public:
         void SetRotation(const glm::quat &rot);
         void SetScale(const glm::vec3 &scale);
 
+        inline void SetStatic() { is_static_ = true; };
+        inline void SetStatic(bool value) { is_static_ = value; }
+
         inline const glm::vec3& GetPosition() const { return position_; }
         inline const glm::quat& GetRotation() const { return rotation_; }
         inline const glm::vec3& GetScale() const { return scale_; }
 
+        inline bool IsStatic() const { return is_static_; }
+
         inline const glm::mat3& GetInertiaTensor() const { return inertia_tensor_; }
+        const glm::mat3& GetInvInertiaWorld();
 
         inline const glm::vec3& GetLinearVelocity() const { return linear_velocity_; }
         inline const glm::vec3& GetAngularVelocity() const { return angular_velocity_; }
@@ -73,9 +81,11 @@ public:
 
         inline float GetMass() const { return mass_; }
 
+        void UpdateCache();
+
         void Draw(wgl::Renderer &renderer);
 
-        glm::mat4 CalculateModelMatrix();
+        glm::mat4 GetModelMatrix();
 };
 
 #endif

--- a/include/rigid_body.h
+++ b/include/rigid_body.h
@@ -32,6 +32,7 @@ class RigidBody {
         bool dirty_;
 
 public:
+        RigidBody() = default;
         RigidBody(Shape shape, float mass, const glm::vec3 &scale);
         ~RigidBody();
 
@@ -40,19 +41,37 @@ public:
         //
         // @param force The force to apply to the body.
         // @param dt Delta time.
-        void IntegrateLinearAcceleration(glm::vec3 force, float dt);               
-        void IntegrateLinearImpulse(glm::vec3 impulse);
+        void IntegrateLinearAcceleration(const glm::vec3 &force, float dt);               
+        void IntegrateLinearImpulse(const glm::vec3 &impulse);
 
-        void IntegrateAngularAcceleration(glm::vec3 force, glm::vec3 r, float dt);
-        void IntegrateAngularImpulse(glm::vec3 impulse, glm::vec3 r);
+        void IntegrateAngularAcceleration(const glm::vec3 &force, const glm::vec3 &r, float dt);
+        void IntegrateAngularImpulse(const glm::vec3 &impulse, const glm::vec3 &r);
 
-        void IntegrateAccelerations(glm::vec3 forces, glm::vec3 r, float dt);
-        void IntegrateImpulses(glm::vec3 impulses, glm::vec3 r, float dt);
+        void IntegrateAccelerations(const glm::vec3 &forces, const glm::vec3 &r, float dt);
+        void IntegrateImpulses(const glm::vec3 &impulses, const glm::vec3 &r);
 
         void IntegrateVelocities(float dt);
 
         void IntegrateLinearVelocity(float dt);
         void IntegrateAngularVelocity(float dt);
+
+        void SetPosition(const glm::vec3 &pos);
+        void SetRotation(const glm::quat &rot);
+        void SetScale(const glm::vec3 &scale);
+
+        inline const glm::vec3& GetPosition() const { return position_; }
+        inline const glm::quat& GetRotation() const { return rotation_; }
+        inline const glm::vec3& GetScale() const { return scale_; }
+
+        inline const glm::mat3& GetInertiaTensor() const { return inertia_tensor_; }
+
+        inline const glm::vec3& GetLinearVelocity() const { return linear_velocity_; }
+        inline const glm::vec3& GetAngularVelocity() const { return angular_velocity_; }
+
+        inline void SetLinearVelocity(const glm::vec3 new_vel) { linear_velocity_ += new_vel; }
+        inline void SetAngularVelocity(const glm::vec3 new_vel) { angular_velocity_ += new_vel; }
+
+        inline float GetMass() const { return mass_; }
 
         void Draw(wgl::Renderer &renderer);
 

--- a/include/rigid_body.h
+++ b/include/rigid_body.h
@@ -25,7 +25,9 @@ class RigidBody {
         glm::vec3 angular_velocity_;
 
         glm::mat3 inertia_tensor_;
-        glm::mat3 cached_inv_inertia_tensor; // World inverse inertia tensor.
+
+        glm::mat3 cached_inv_inertia_tensor_; // World inverse inertia tensor.
+        glm::mat3 cached_inertia_tensor_;     // World inertia tensor.
         glm::mat4 cached_model_;
 
         wgl::Mesh *mesh_;
@@ -72,6 +74,7 @@ public:
 
         inline const glm::mat3& GetInertiaTensor() const { return inertia_tensor_; }
         const glm::mat3& GetInvInertiaWorld();
+        const glm::mat3& GetInertiaWorld();
 
         inline const glm::vec3& GetLinearVelocity() const { return linear_velocity_; }
         inline const glm::vec3& GetAngularVelocity() const { return angular_velocity_; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 
 #include <GLFW/glfw3.h>
 
-#include "../include/rigid_body.h"
+#include "../include/pendulum.h"
 #include "../include/math/constants.h"
 
 constexpr float kInitialWindowWidth  = 800.0f;
@@ -46,11 +46,9 @@ int main(void)
                         0.1f,
                         1000.0f);
 
-        camera.SetPosition(vec3(0.0f, 2.5f, 8.0f));
-        camera.SetRotation(vec3(/*pitch*/-20.0f, /*yaw*/-90.0f, 0.0f));
+        camera.SetPosition(vec3(0.0f, 0.0f, 30.0f));
 
-        RigidBody body = RigidBody(Shape::kPyramid, 5.0f, vec3(1.0f, 1.0f, 1.0f));
-        //body.IntegrateLinearVelocity(glm::vec3(0.0f, 20.0f, -60.0f, dt);
+        Pendulum pendulum(vec3(0.0f, 0.0f, 0.0f), 3.0f);
 
         bool is_first = true;
 
@@ -63,16 +61,15 @@ int main(void)
                 camera.Update();
 
                 // Apply gravity.
-                body.IntegrateLinearAcceleration(glm::vec3(0.0f, -kGravity * 2.0, 0.0f), dt);
+                pendulum.GetBob()->IntegrateLinearAcceleration(glm::vec3(0.0f, -kGravity * 2.0, 0.0f), dt);
 
                 if (is_first) {
-                        body.IntegrateImpulses(glm::vec3(10.0f, 20.0f, -60.0f), glm::vec3(0.080f, 0.030f, 0.080f), dt);
+                        pendulum.GetBob()->IntegrateLinearImpulse(glm::vec3(60.0f, 0.0f, -80.0f));
                         is_first = false;
                 }
 
-                body.IntegrateVelocities(dt);
-
-                body.Draw(renderer);
+                pendulum.Draw(renderer);
+                pendulum.Update(dt);
 
                 window.SwapBuffers();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,11 +46,12 @@ int main(void)
                         0.1f,
                         1000.0f);
 
-        camera.SetPosition(vec3(0.0f, 0.0f, 30.0f));
+        camera.SetPosition(vec3(0.0f, 0.0f, 18.0f));
 
-        Pendulum pendulum(vec3(0.0f, 0.0f, 0.0f), 3.0f);
+        Pendulum pendulum(vec3(0.0f, 0.0f, 0.0f), 3.0f, true);
 
         bool is_first = true;
+        int frames = 0;
 
         while (!window.ShouldClose()) {
                 auto curr_t = std::chrono::high_resolution_clock::now();
@@ -64,8 +65,12 @@ int main(void)
                 pendulum.GetBob()->IntegrateLinearAcceleration(glm::vec3(0.0f, -kGravity * 2.0, 0.0f), dt);
 
                 if (is_first) {
-                        pendulum.GetBob()->IntegrateLinearImpulse(glm::vec3(60.0f, 0.0f, -80.0f));
+                        pendulum.GetBob()->IntegrateLinearImpulse(glm::vec3(30.0f, 0.0f, 0.0f));
                         is_first = false;
+                }
+
+                if (frames++ == 2000) {
+                        pendulum.GetBob()->IntegrateLinearImpulse(glm::vec3(60.0f, 0.0f, 50.0f));
                 }
 
                 pendulum.Draw(renderer);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,9 +46,10 @@ int main(void)
                         0.1f,
                         1000.0f);
 
-        camera.SetPosition(vec3(0.0f, 0.0f, 18.0f));
+        camera.SetPosition(vec3(0.0f, 0.0f, 30.0f));
 
-        Pendulum pendulum(vec3(0.0f, 0.0f, 0.0f), 3.0f, true);
+        Pendulum pendulum1(vec3(5.0f, 0.0f, 0.0f), 3, 4.0f, true);
+        Pendulum pendulum2(vec3(-5.0f, 0.0f, 0.0f), 3, 4.0f, true);
 
         bool is_first = true;
         int frames = 0;
@@ -61,20 +62,31 @@ int main(void)
                 renderer.Clear(0.1, 0.1, 0.1, 1.0f, true);
                 camera.Update();
 
-                // Apply gravity.
-                pendulum.GetBob()->IntegrateLinearAcceleration(glm::vec3(0.0f, -kGravity * 2.0, 0.0f), dt);
+                for (size_t i = 0; i < 3; ++i) {
+                        // Apply gravity.
+                        pendulum1.GetBob(i)->IntegrateLinearAcceleration(glm::vec3(0.0f, -kGravity * 6.0, 0.0f), dt);
+                        pendulum2.GetBob(i)->IntegrateLinearAcceleration(glm::vec3(0.0f, -kGravity * 6.0, 0.0f), dt);
 
-                if (is_first) {
-                        pendulum.GetBob()->IntegrateLinearImpulse(glm::vec3(30.0f, 0.0f, 0.0f));
-                        is_first = false;
+                        if (is_first) {
+                                pendulum1.GetBob(1)->IntegrateLinearImpulse(glm::vec3(0.001f, 0.0f, 0.0f));
+                                pendulum2.GetBob(1)->IntegrateLinearImpulse(glm::vec3(0.001f, 0.0f, 0.0f));
+                                is_first = false;
+                        }
+
+                        if (frames++ == 1000) {
+                                pendulum1.GetBob(2)->IntegrateLinearImpulse(glm::vec3(100.0f, 0.0f, 0.0f));
+                                pendulum2.GetBob(2)->IntegrateLinearImpulse(glm::vec3(100.0f, 0.0f, 0.0f));
+                                pendulum1.GetBob(1)->IntegrateLinearImpulse(glm::vec3(-150.0f, 0.0f, 0.0f));
+                                pendulum2.GetBob(1)->IntegrateLinearImpulse(glm::vec3(-150.0f, 0.0f, 0.0f));
+                                //pendulum.GetBob(1)->IntegrateLinearImpulse(glm::vec3(-200.0f, 0.0f, 0.0f));
+                        }
                 }
 
-                if (frames++ == 2000) {
-                        pendulum.GetBob()->IntegrateLinearImpulse(glm::vec3(60.0f, 0.0f, 50.0f));
-                }
+                pendulum1.Update(dt);
+                pendulum2.Update(dt);
 
-                pendulum.Draw(renderer);
-                pendulum.Update(dt);
+                pendulum1.Draw(renderer);
+                pendulum2.Draw(renderer);
 
                 window.SwapBuffers();
 

--- a/src/pendulum.cpp
+++ b/src/pendulum.cpp
@@ -1,0 +1,107 @@
+#include "../include/pendulum.h"
+
+#include <algorithm>
+#include <cmath>
+#include <glm/matrix.hpp>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/quaternion.hpp>
+#include <glm/ext/matrix_transform.hpp>
+#include <glm/glm.hpp>
+
+#include "../include/math/constants.h"
+
+using namespace glm;
+
+Pendulum::Pendulum(const vec3 &pivot_pos, float rod_lenght) :
+        pivot_(RigidBody(Shape::kCube, 3.0f, vec3(1.0f, 1.0f, 1.0f))),
+        bob_(RigidBody(Shape::kCube, 2.0f, vec3(1.0f, 1.0f, 1.0f)))
+{
+        rod_lenght_ = rod_lenght;
+
+        pivot_.SetPosition(pivot_pos);
+        bob_.SetPosition(vec3(pivot_pos.x, pivot_pos.y - rod_lenght_, pivot_pos.z));
+
+        // The attachment point will be their center of mass (position)
+        pivot_attach_ = vec3(pivot_.GetPosition().x, pivot_.GetPosition().y + pivot_.GetScale().y, pivot_.GetPosition().z);
+        bob_attach_   = vec3(bob_.GetPosition());
+}
+
+void Pendulum::Update(float dt)
+{
+        // World position of the pivot attachment point to the bob.
+        vec3 pivot_attach_wrld = pivot_.GetPosition() + toMat3(pivot_.GetRotation()) * pivot_attach_;
+
+        // World position of the bob attachment point to the pivot.
+        vec3 bob_attach_wrld = bob_.GetPosition() + toMat3(bob_.GetRotation()) * bob_attach_;
+        
+        // d is just the straight line vector from the pivot to the bob in
+        // world space.
+        vec3 d = bob_attach_wrld - pivot_attach_wrld;
+        const float eps = 1e-6f;
+
+        // l is the lenght of d. AKA the real distance between the pivot and
+        // the bob in the current frame.
+        float l = std::sqrt(d.x * d.x + d.y * d.y + d.z * d.z);
+
+        if (l < eps) {
+                return;
+        }
+
+        // n is the normalized direction along the rod.
+        vec3 n = d / l;
+
+        vec3 pivot_r = pivot_attach_wrld - pivot_.GetPosition();
+        vec3 bob_r = bob_attach_wrld - bob_.GetPosition();
+
+        vec3 vel_at_pivot = pivot_.GetLinearVelocity() + cross(pivot_.GetAngularVelocity(), pivot_r);
+        vec3 vel_at_bob = bob_.GetLinearVelocity() + cross(bob_.GetAngularVelocity(), bob_r);
+
+        float relative_vel_along_rod = dot(vel_at_bob - vel_at_pivot, n);
+
+        float positional_error = l - rod_lenght_;
+
+        //static const float kMaxBias = 10.0f;
+        float bias_vel = kConstraintStiffness * positional_error / dt;
+
+        float k_trans = 1.0f / pivot_.GetMass() + 1.0f / bob_.GetMass();
+
+        vec3 r_p_cross_n = cross(pivot_r, n);
+        vec3 r_b_cross_n = cross(bob_r, n);
+
+        vec3 pivot_rot_resist = inverse(pivot_.GetInertiaTensor()) * r_p_cross_n;
+        vec3 bob_rot_resist   = inverse(bob_.GetInertiaTensor()) * r_b_cross_n;
+
+        float k_rot_pivot = dot(r_p_cross_n, pivot_rot_resist);
+        float k_rot_bob   = dot(r_b_cross_n, bob_rot_resist);
+
+        // k is the effective mass of the rod constraint along its direction.
+        // A scalar that tells us how "hard" it is to move the pivot and bob
+        // along the rod.
+        float k = k_trans + k_rot_pivot + k_rot_bob;
+        if (k < eps) {
+                return;
+        }
+
+        // This is the magnitude of the impulse along the rod direction n
+        // needed to correct both the current velocity and positional error.
+        //
+        // Also known as P
+        float P = - (relative_vel_along_rod + bias_vel) / k;
+        vec3 J = n * P;
+
+        // Apply P to the linear and angular velocities of both bodies
+        pivot_.IntegrateLinearImpulse(-J);
+        bob_.IntegrateLinearImpulse(J);
+
+        pivot_.IntegrateAngularImpulse(-J, pivot_r);
+        bob_.IntegrateAngularImpulse(J, bob_r);
+
+        bob_.IntegrateVelocities(dt);
+}
+
+void Pendulum::Draw(wgl::Renderer &renderer)
+{
+        pivot_.Draw(renderer);
+        bob_.Draw(renderer);
+}

--- a/src/pendulum.cpp
+++ b/src/pendulum.cpp
@@ -1,30 +1,37 @@
 #include "../include/pendulum.h"
 
-#include <glm/matrix.hpp>
 #include <wrapgl/renderer.h>
 
 #define GLM_ENABLE_EXPERIMENTAL
+#include <glm/glm.hpp>
+#include <glm/matrix.hpp>
 #include <glm/gtx/quaternion.hpp>
 #include <glm/ext/matrix_transform.hpp>
-#include <glm/glm.hpp>
 
 #include "../include/math/constants.h"
 
 using namespace glm;
 
-Pendulum::Pendulum(const vec3 &pivot_pos, float rod_length, bool is_static) :
-        pivot_(RigidBody(Shape::kCube, 3.0f, vec3(1.0f, 1.0f, 1.0f), is_static)),
-        bob_(RigidBody(Shape::kCube, 2.0f, vec3(1.0f, 1.0f, 1.0f), false))
+Pendulum::Pendulum(const vec3 &pos, size_t num_bobs, float rod_length, bool is_static) :
+        rod_length_(rod_length)
 {
-        rod_length_ = rod_length;
+        bobs_.reserve(num_bobs);
+        bobs_attach_.resize(num_bobs);
+        bobs_attach_wrld_.resize(num_bobs);
 
-        pivot_.SetPosition(pivot_pos);
-        bob_.SetPosition(vec3(pivot_pos.x, pivot_pos.y - rod_length_, pivot_pos.z));
+        for (size_t i = 0; i < num_bobs; ++i) {
+                glm::vec3 pos_i = (i == 0) ? pos : glm::vec3(
+                                bobs_[i-1].GetPosition().x,
+                                bobs_[i-1].GetPosition().y - rod_length_,
+                                bobs_[i-1].GetPosition().z
+                                );
 
-        // The attachment point will be their center of mass (position)
-        pivot_attach_ = vec3(pivot_.GetPosition());
-        bob_attach_   = vec3(bob_.GetPosition());
-
+                bobs_.emplace_back(Shape::kCube, 5.0f, glm::vec3(1.0f), i == 0 ? is_static : false);
+                bobs_.back().SetPosition(pos_i);
+                bobs_attach_.push_back(pos_i);
+                bobs_attach_wrld_.push_back(pos_i);
+        }
+        
         glGenVertexArrays(1, &line_vao_);
         glGenBuffers(1, &line_vbo_);
 
@@ -50,108 +57,121 @@ Pendulum::Pendulum(const vec3 &pivot_pos, float rod_length, bool is_static) :
 
 void Pendulum::Draw(wgl::Renderer &renderer)
 {
-        UpdateBobAttachWorld();
-        UpdatePivotAttachWorld();
+        if (bobs_.empty()) return;
 
-        pivot_.Draw(renderer);
-        bob_.Draw(renderer);
+        // Draw all bodies
+        for (size_t i = 0; i < bobs_.size(); ++i) {
+                bobs_[i].Draw(renderer);
+        }
 
-        float line[12] = {
-        // pivot position + color
-        pivot_.GetPosition().x, pivot_.GetPosition().y, pivot_.GetPosition().z,  1.0f, 1.0f, 1.0f,
-        // bob position + color
-        bob_.GetPosition().x,   bob_.GetPosition().y,   bob_.GetPosition().z,    1.0f, 1.0f, 1.0f
-        };
+        // Prepare a buffer for all lines (2 vertices per line, 6 floats per vertex)
+        size_t num_lines = bobs_.size() - 1;
+        std::vector<float> line_vertices;
+        line_vertices.reserve(num_lines * 2 * 6);
 
-        // update the GPU buffer
+        for (size_t i = 1; i < bobs_.size(); ++i) {
+                glm::vec3 start = bobs_[i - 1].GetPosition();
+                glm::vec3 end   = bobs_[i].GetPosition();
+
+                // Start vertex: position + color
+                line_vertices.insert(line_vertices.end(), {start.x, start.y, start.z, 1.0f, 1.0f, 1.0f});
+                // End vertex: position + color
+                line_vertices.insert(line_vertices.end(), {end.x,   end.y,   end.z,   1.0f, 1.0f, 1.0f});
+        }
+
+        // Upload all line vertices at once
         glBindBuffer(GL_ARRAY_BUFFER, line_vbo_);
-        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(line), line);
+        glBufferData(GL_ARRAY_BUFFER, line_vertices.size() * sizeof(float), line_vertices.data(), GL_DYNAMIC_DRAW);
 
-        // bind the shader
+        // Bind VAO and shader
+        glBindVertexArray(line_vao_);
         renderer.SetUniformMatrix4f("model", glm::mat4(1.0f));
 
-        // draw the line
-        renderer.DrawArrays(line_vao_, GL_LINES, 2);
+        // Draw all lines in a single draw call
+        renderer.DrawArrays(line_vao_, GL_LINES, static_cast<GLsizei>(num_lines * 2));
+
         glBindVertexArray(0);
 }
 
-void Pendulum::UpdatePivotAttachWorld()
+void Pendulum::UpdateBobAttachWorld(size_t i)
 {
-        pivot_attach_wrld_ = pivot_.GetPosition() + toMat3(pivot_.GetRotation()) * pivot_attach_;
-}
-
-void Pendulum::UpdateBobAttachWorld()
-{
-        bob_attach_wrld_ = bob_.GetPosition() + toMat3(bob_.GetRotation()) * bob_attach_;
+        bobs_attach_wrld_[i] = bobs_[i].GetPosition() + toMat3(bobs_[i].GetRotation()) * bobs_attach_[i];
 }
 
 void Pendulum::Update(float dt)
 {
         if (dt <= 0.0f) return;
 
-        UpdatePivotAttachWorld();
-        UpdateBobAttachWorld();
+        for (size_t i = 1; i < bobs_.size(); i++) {
+                UpdateBobAttachWorld(i);
+                UpdateBobAttachWorld(i-1);
 
-        const float kEpsilon = 1e-6f;
-        glm::vec3 d = bob_attach_wrld_ - pivot_attach_wrld_;
-        float l = glm::length(d);
-        if (l < kEpsilon) return;
+                RigidBody *pivot = GetBob(i - 1);
+                RigidBody *bob   = GetBob(i);
 
-        glm::vec3 n = d / l;
-        glm::vec3 pivot_r = pivot_attach_wrld_ - pivot_.GetPosition();
-        glm::vec3 bob_r   = bob_attach_wrld_   - bob_.GetPosition();
+                glm::vec3 bob_attach_wrld = bobs_attach_wrld_[i];
+                glm::vec3 pivot_attach_wrld = bobs_attach_wrld_[i-1];
 
-        glm::vec3 vel_at_pivot = pivot_.GetLinearVelocity() + glm::cross(pivot_.GetAngularVelocity(), pivot_r);
-        glm::vec3 vel_at_bob   = bob_.GetLinearVelocity()   + glm::cross(bob_.GetAngularVelocity(), bob_r);
+                const float kEpsilon = 1e-6f;
+                glm::vec3 d = bob_attach_wrld - pivot_attach_wrld;
+                float l = glm::length(d);
+                if (l < kEpsilon) return;
 
-        float relative_vel_along_rod = glm::dot(vel_at_bob - vel_at_pivot, n);
-        float positional_error = l - rod_length_;
+                glm::vec3 n = d / l;
+                glm::vec3 pivot_r = pivot_attach_wrld - pivot->GetPosition();
+                glm::vec3 bob_r   = bob_attach_wrld - bob->GetPosition();
 
-        // bias safe
-        const float kBiasFactor = 0.2f;
-        float bias_vel = (kConstraintStiffness * positional_error) * (kBiasFactor / dt);
+                glm::vec3 vel_at_pivot = pivot->GetLinearVelocity() + glm::cross(pivot->GetAngularVelocity(), pivot_r);
+                glm::vec3 vel_at_bob   = bob->GetLinearVelocity()   + glm::cross(bob->GetAngularVelocity(), bob_r);
 
-        // inverse masses (safe)
-        float invMassPivot = pivot_.IsStatic() ? 0.0f : (pivot_.GetMass() > 0.0f ? 1.0f / pivot_.GetMass() : 0.0f);
-        float invMassBob   = bob_.GetMass() > 0.0f ? 1.0f / bob_.GetMass() : 0.0f;
-        float k_trans = invMassPivot + invMassBob;
+                float relative_vel_along_rod = glm::dot(vel_at_bob - vel_at_pivot, n);
+                float positional_error = l - rod_length_;
 
-        // inverse inertia in world space — if pivot static, use zero matrix
-        glm::mat3 invI_pivot = pivot_.IsStatic() ? glm::mat3(0.0f) : pivot_.GetInvInertiaWorld(); // ideally cached
-        glm::mat3 invI_bob   = bob_.GetInvInertiaWorld();
+                const float kBiasFactor = 0.99f;
+                float bias_vel = (kConstraintStiffness * positional_error) * (kBiasFactor / dt);
 
-        glm::vec3 r_p_cross_n = glm::cross(pivot_r, n);
-        glm::vec3 r_b_cross_n = glm::cross(bob_r, n);
+                // inverse masses (safe)
+                float invMassPivot = pivot->IsStatic() ? 0.0f : (pivot->GetMass() > 0.0f ? 1.0f / pivot->GetMass() : 0.0f);
+                float invMassBob   = bob->GetMass() > 0.0f ? 1.0f / bob->GetMass() : 0.0f;
+                float k_trans = invMassPivot + invMassBob;
 
-        glm::vec3 pivot_rot_resist = invI_pivot * r_p_cross_n;
-        glm::vec3 bob_rot_resist   = invI_bob   * r_b_cross_n;
+                // inverse inertia in world space — if pivot static, use zero matrix
+                glm::mat3 invI_pivot = pivot->IsStatic() ? glm::mat3(0.0f) : pivot->GetInvInertiaWorld(); // ideally cached
+                glm::mat3 invI_bob   = bob->GetInvInertiaWorld();
 
-        float k_rot_pivot = glm::dot(r_p_cross_n, pivot_rot_resist);
-        float k_rot_bob   = glm::dot(r_b_cross_n, bob_rot_resist);
+                glm::vec3 r_p_cross_n = glm::cross(pivot_r, n);
+                glm::vec3 r_b_cross_n = glm::cross(bob_r, n);
 
-        float k = k_trans + k_rot_pivot + k_rot_bob;
-        if (k < kEpsilon) return;
+                glm::vec3 pivot_rot_resist = invI_pivot * r_p_cross_n;
+                glm::vec3 bob_rot_resist   = invI_bob   * r_b_cross_n;
 
-        float P = - (relative_vel_along_rod + bias_vel) / k;
+                float k_rot_pivot = glm::dot(r_p_cross_n, pivot_rot_resist);
+                float k_rot_bob   = glm::dot(r_b_cross_n, bob_rot_resist);
 
-        // clamp impulse for stability
-        const float kMaxImpulse = 1000.0f;
-        P = glm::clamp(P, -kMaxImpulse, kMaxImpulse);
+                float k = k_trans + k_rot_pivot + k_rot_bob;
+                if (k < kEpsilon) return;
 
-        glm::vec3 J = n * P;
+                float P = - (relative_vel_along_rod + bias_vel) / k;
 
-        // Apply to bob always
-        bob_.IntegrateLinearImpulse(J);
-        bob_.IntegrateAngularImpulse(J, bob_r);
+                // clamp impulse for stability
+                const float kMaxImpulse = 1000.0f;
+                P = glm::clamp(P, -kMaxImpulse, kMaxImpulse);
 
-        // Do NOT apply to pivot if it's static
-        if (!pivot_.IsStatic()) {
-                pivot_.IntegrateLinearImpulse(-J);
-                pivot_.IntegrateAngularImpulse(-J, pivot_r);
+                glm::vec3 J = n * P;
+
+                // Apply to bob always
+                bob->IntegrateLinearImpulse(J);
+                bob->IntegrateAngularImpulse(J, bob_r);
+
+                // Do NOT apply to pivot if it's static
+                if (!pivot->IsStatic()) {
+                        pivot->IntegrateLinearImpulse(-J);
+                        pivot->IntegrateAngularImpulse(-J, pivot_r);
+                }
         }
 
-        // Integrate velocities for bodies that can move
-        if (!pivot_.IsStatic()) pivot_.IntegrateVelocities(dt);
-        bob_.IntegrateVelocities(dt);
+        for (auto &bob : bobs_) {
+                bob.IntegrateVelocities(dt);
+        }
 }
 

--- a/src/pendulum.cpp
+++ b/src/pendulum.cpp
@@ -1,8 +1,7 @@
 #include "../include/pendulum.h"
 
-#include <algorithm>
-#include <cmath>
 #include <glm/matrix.hpp>
+#include <wrapgl/renderer.h>
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/quaternion.hpp>
@@ -13,95 +12,146 @@
 
 using namespace glm;
 
-Pendulum::Pendulum(const vec3 &pivot_pos, float rod_lenght) :
-        pivot_(RigidBody(Shape::kCube, 3.0f, vec3(1.0f, 1.0f, 1.0f))),
-        bob_(RigidBody(Shape::kCube, 2.0f, vec3(1.0f, 1.0f, 1.0f)))
+Pendulum::Pendulum(const vec3 &pivot_pos, float rod_length, bool is_static) :
+        pivot_(RigidBody(Shape::kCube, 3.0f, vec3(1.0f, 1.0f, 1.0f), is_static)),
+        bob_(RigidBody(Shape::kCube, 2.0f, vec3(1.0f, 1.0f, 1.0f), false))
 {
-        rod_lenght_ = rod_lenght;
+        rod_length_ = rod_length;
 
         pivot_.SetPosition(pivot_pos);
-        bob_.SetPosition(vec3(pivot_pos.x, pivot_pos.y - rod_lenght_, pivot_pos.z));
+        bob_.SetPosition(vec3(pivot_pos.x, pivot_pos.y - rod_length_, pivot_pos.z));
 
         // The attachment point will be their center of mass (position)
-        pivot_attach_ = vec3(pivot_.GetPosition().x, pivot_.GetPosition().y + pivot_.GetScale().y, pivot_.GetPosition().z);
+        pivot_attach_ = vec3(pivot_.GetPosition());
         bob_attach_   = vec3(bob_.GetPosition());
-}
 
-void Pendulum::Update(float dt)
-{
-        // World position of the pivot attachment point to the bob.
-        vec3 pivot_attach_wrld = pivot_.GetPosition() + toMat3(pivot_.GetRotation()) * pivot_attach_;
+        glGenVertexArrays(1, &line_vao_);
+        glGenBuffers(1, &line_vbo_);
 
-        // World position of the bob attachment point to the pivot.
-        vec3 bob_attach_wrld = bob_.GetPosition() + toMat3(bob_.GetRotation()) * bob_attach_;
-        
-        // d is just the straight line vector from the pivot to the bob in
-        // world space.
-        vec3 d = bob_attach_wrld - pivot_attach_wrld;
-        const float eps = 1e-6f;
+        glBindVertexArray(line_vao_);
+        glBindBuffer(GL_ARRAY_BUFFER, line_vbo_);
 
-        // l is the lenght of d. AKA the real distance between the pivot and
-        // the bob in the current frame.
-        float l = std::sqrt(d.x * d.x + d.y * d.y + d.z * d.z);
+        const GLsizeiptr vertex_size  = sizeof(float) * 6;
+        const GLsizeiptr vertex_count = 2;
 
-        if (l < eps) {
-                return;
-        }
+        // allocate buffer (two vec3 positions, but initially empty)
+        glBufferData(GL_ARRAY_BUFFER, vertex_size * vertex_count, nullptr, GL_DYNAMIC_DRAW);
 
-        // n is the normalized direction along the rod.
-        vec3 n = d / l;
+        // describe layout: attribute 0 = vec3 position
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, vertex_size, (void*)0);
 
-        vec3 pivot_r = pivot_attach_wrld - pivot_.GetPosition();
-        vec3 bob_r = bob_attach_wrld - bob_.GetPosition();
+        // color at location = 1
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, vertex_size, (void*)(sizeof(float) * 3));
 
-        vec3 vel_at_pivot = pivot_.GetLinearVelocity() + cross(pivot_.GetAngularVelocity(), pivot_r);
-        vec3 vel_at_bob = bob_.GetLinearVelocity() + cross(bob_.GetAngularVelocity(), bob_r);
-
-        float relative_vel_along_rod = dot(vel_at_bob - vel_at_pivot, n);
-
-        float positional_error = l - rod_lenght_;
-
-        //static const float kMaxBias = 10.0f;
-        float bias_vel = kConstraintStiffness * positional_error / dt;
-
-        float k_trans = 1.0f / pivot_.GetMass() + 1.0f / bob_.GetMass();
-
-        vec3 r_p_cross_n = cross(pivot_r, n);
-        vec3 r_b_cross_n = cross(bob_r, n);
-
-        vec3 pivot_rot_resist = inverse(pivot_.GetInertiaTensor()) * r_p_cross_n;
-        vec3 bob_rot_resist   = inverse(bob_.GetInertiaTensor()) * r_b_cross_n;
-
-        float k_rot_pivot = dot(r_p_cross_n, pivot_rot_resist);
-        float k_rot_bob   = dot(r_b_cross_n, bob_rot_resist);
-
-        // k is the effective mass of the rod constraint along its direction.
-        // A scalar that tells us how "hard" it is to move the pivot and bob
-        // along the rod.
-        float k = k_trans + k_rot_pivot + k_rot_bob;
-        if (k < eps) {
-                return;
-        }
-
-        // This is the magnitude of the impulse along the rod direction n
-        // needed to correct both the current velocity and positional error.
-        //
-        // Also known as P
-        float P = - (relative_vel_along_rod + bias_vel) / k;
-        vec3 J = n * P;
-
-        // Apply P to the linear and angular velocities of both bodies
-        pivot_.IntegrateLinearImpulse(-J);
-        bob_.IntegrateLinearImpulse(J);
-
-        pivot_.IntegrateAngularImpulse(-J, pivot_r);
-        bob_.IntegrateAngularImpulse(J, bob_r);
-
-        bob_.IntegrateVelocities(dt);
+        glBindVertexArray(0);
 }
 
 void Pendulum::Draw(wgl::Renderer &renderer)
 {
+        UpdateBobAttachWorld();
+        UpdatePivotAttachWorld();
+
         pivot_.Draw(renderer);
         bob_.Draw(renderer);
+
+        float line[12] = {
+        // pivot position + color
+        pivot_.GetPosition().x, pivot_.GetPosition().y, pivot_.GetPosition().z,  1.0f, 1.0f, 1.0f,
+        // bob position + color
+        bob_.GetPosition().x,   bob_.GetPosition().y,   bob_.GetPosition().z,    1.0f, 1.0f, 1.0f
+        };
+
+        // update the GPU buffer
+        glBindBuffer(GL_ARRAY_BUFFER, line_vbo_);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(line), line);
+
+        // bind the shader
+        renderer.SetUniformMatrix4f("model", glm::mat4(1.0f));
+
+        // draw the line
+        renderer.DrawArrays(line_vao_, GL_LINES, 2);
+        glBindVertexArray(0);
 }
+
+void Pendulum::UpdatePivotAttachWorld()
+{
+        pivot_attach_wrld_ = pivot_.GetPosition() + toMat3(pivot_.GetRotation()) * pivot_attach_;
+}
+
+void Pendulum::UpdateBobAttachWorld()
+{
+        bob_attach_wrld_ = bob_.GetPosition() + toMat3(bob_.GetRotation()) * bob_attach_;
+}
+
+void Pendulum::Update(float dt)
+{
+        if (dt <= 0.0f) return;
+
+        UpdatePivotAttachWorld();
+        UpdateBobAttachWorld();
+
+        const float kEpsilon = 1e-6f;
+        glm::vec3 d = bob_attach_wrld_ - pivot_attach_wrld_;
+        float l = glm::length(d);
+        if (l < kEpsilon) return;
+
+        glm::vec3 n = d / l;
+        glm::vec3 pivot_r = pivot_attach_wrld_ - pivot_.GetPosition();
+        glm::vec3 bob_r   = bob_attach_wrld_   - bob_.GetPosition();
+
+        glm::vec3 vel_at_pivot = pivot_.GetLinearVelocity() + glm::cross(pivot_.GetAngularVelocity(), pivot_r);
+        glm::vec3 vel_at_bob   = bob_.GetLinearVelocity()   + glm::cross(bob_.GetAngularVelocity(), bob_r);
+
+        float relative_vel_along_rod = glm::dot(vel_at_bob - vel_at_pivot, n);
+        float positional_error = l - rod_length_;
+
+        // bias safe
+        const float kBiasFactor = 0.2f;
+        float bias_vel = (kConstraintStiffness * positional_error) * (kBiasFactor / dt);
+
+        // inverse masses (safe)
+        float invMassPivot = pivot_.IsStatic() ? 0.0f : (pivot_.GetMass() > 0.0f ? 1.0f / pivot_.GetMass() : 0.0f);
+        float invMassBob   = bob_.GetMass() > 0.0f ? 1.0f / bob_.GetMass() : 0.0f;
+        float k_trans = invMassPivot + invMassBob;
+
+        // inverse inertia in world space — if pivot static, use zero matrix
+        glm::mat3 invI_pivot = pivot_.IsStatic() ? glm::mat3(0.0f) : pivot_.GetInvInertiaWorld(); // ideally cached
+        glm::mat3 invI_bob   = bob_.GetInvInertiaWorld();
+
+        glm::vec3 r_p_cross_n = glm::cross(pivot_r, n);
+        glm::vec3 r_b_cross_n = glm::cross(bob_r, n);
+
+        glm::vec3 pivot_rot_resist = invI_pivot * r_p_cross_n;
+        glm::vec3 bob_rot_resist   = invI_bob   * r_b_cross_n;
+
+        float k_rot_pivot = glm::dot(r_p_cross_n, pivot_rot_resist);
+        float k_rot_bob   = glm::dot(r_b_cross_n, bob_rot_resist);
+
+        float k = k_trans + k_rot_pivot + k_rot_bob;
+        if (k < kEpsilon) return;
+
+        float P = - (relative_vel_along_rod + bias_vel) / k;
+
+        // clamp impulse for stability
+        const float kMaxImpulse = 1000.0f;
+        P = glm::clamp(P, -kMaxImpulse, kMaxImpulse);
+
+        glm::vec3 J = n * P;
+
+        // Apply to bob always
+        bob_.IntegrateLinearImpulse(J);
+        bob_.IntegrateAngularImpulse(J, bob_r);
+
+        // Do NOT apply to pivot if it's static
+        if (!pivot_.IsStatic()) {
+                pivot_.IntegrateLinearImpulse(-J);
+                pivot_.IntegrateAngularImpulse(-J, pivot_r);
+        }
+
+        // Integrate velocities for bodies that can move
+        if (!pivot_.IsStatic()) pivot_.IntegrateVelocities(dt);
+        bob_.IntegrateVelocities(dt);
+}
+


### PR DESCRIPTION
## Overview

This PR introduces a new Pendulum class which allows for N-body pendulum simulations, like double, triple (or however many you'd like) pendulums.

## Key changes
- `Pendulum` class with customizable bob mass and rod length.
- Fixed physics bugs in `RigidBody` class.
- Added energy conservation to RigidBody.